### PR TITLE
chore: add dummy line comment in release.yml for server-acl CI maintenance task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,5 @@ jobs:
             echo "### Release Notes for \`$BRANCH\`" >> $GITHUB_STEP_SUMMARY
             echo "$NOTES" >> $GITHUB_STEP_SUMMARY
           fi
+
+      # Dummy unrelated change in .github/workflows/release.yml | server-acl | Batch 1


### PR DESCRIPTION
This PR adds a dummy line comment in the release.yml file to simulate a CI maintenance task for the server-acl branch.